### PR TITLE
Pass form state by reference.

### DIFF
--- a/includes/external_auth_login_controller.inc
+++ b/includes/external_auth_login_controller.inc
@@ -5,7 +5,7 @@
  */
 interface ExternalAuthLoginController
 {
-    public function setup(Array $form, Array $form_state);
+    public function setup(Array $form, Array &$form_state);
     public function loginExists();
     public function loginExistingUser();
     public function getRemoteUser();

--- a/includes/external_auth_register_controller.inc
+++ b/includes/external_auth_register_controller.inc
@@ -5,7 +5,7 @@
  */
 interface ExternalAuthRegisterController
 {
-  public function setup(Array $form, Array $form_state);
+  public function setup(Array $form, Array &$form_state);
   public function signup();
   public function processSignupErrors(Array $form);
 }


### PR DESCRIPTION
Fix argument compatibility broken by #3.

Error example:
![1414096108028-fail](https://cloud.githubusercontent.com/assets/672669/4760910/c764507c-5af3-11e4-8763-a85ba886e7d7.png)
